### PR TITLE
add gog error checking

### DIFF
--- a/greenongreen.py
+++ b/greenongreen.py
@@ -12,17 +12,23 @@ import os
 
 class GreenOnGreen:
     def __init__(self, algorithm='gog', label_file='models/labels.txt'):
-        if algorithm == 'gog':
-            self.algorithm_file = Path(glob('models/*.tflite')[0])
-            print(f'[INFO] Using {self.algorithm_file.stem} model...')
+        model_files = glob('models/*.tflite')
+
+        if not model_files:
+            raise FileNotFoundError('No .tflite model files found.')
 
         elif algorithm.endswith('.tflite'):
-            self.algorithm_file = Path(algorithm)
-            print(f'[INFO] Using {self.algorithm_file.stem} model...')
+            if Path(algorithm).is_file():
+                self.algorithm_file = Path(algorithm)
+                print(f'[INFO] Using {self.algorithm_file.stem} model...')
+            else:
+                print(f'[ERROR] Specified algorithm file {algorithm} not found, using default...')
+                self.algorithm_file = Path(model_files[0])
+                print(f'[INFO] Using {self.algorithm_file.stem} model...')
 
         else:
             print(f'[ERROR] Unknown algorithm {algorithm}, using default...')
-            self.algorithm_file = Path(glob('models/*.tflite')[0])
+            self.algorithm_file = Path(model_files[0])
             print(f'[INFO] Using {self.algorithm_file.stem} model...')
 
         self.labels = read_label_file(label_file)

--- a/owl.py
+++ b/owl.py
@@ -265,11 +265,35 @@ class Owl:
             else:
                 weed_detector = GreenOnBrown(algorithm=algorithm)
 
-        except Exception as e:
-            self.logger.log_line(f"[ALGORITHM ERROR] Error while starting algorithm: {algorithm}."
-                                 f"Original error message: {e}")
+        except ModuleNotFoundError as e:
+            self.logger.log_line(f"\nModuleNotFoundError while starting algorithm: {algorithm}."
+                                 f"\nError message: {e}.\nIs pycoral correctly installed? Visit: https://coral.ai/docs/accelerator/get-started/#requirements",
+                                 verbose=True)
 
-            self.controller.solenoid.beep(duration=0.5, repeats=4)
+            self.controller.solenoid.beep(duration=0.25, repeats=4)
+            sys.exit()
+
+        except IndexError as e:
+            self.logger.log_line(f"\nIndexError while starting algorithm: {algorithm}."
+                                 f"\nError message: {e}\nAre there model files in the 'models' directory?",
+                                 verbose=True)
+
+            self.controller.solenoid.beep(duration=0.25, repeats=4)
+            sys.exit()
+
+        except FileNotFoundError as e:
+            self.logger.log_line(f"\nFileNotFoundError while starting algorithm: {algorithm}."
+                                 f"\nError message: {e}\nAre there model files in the 'models' directory?",
+                                 verbose=True)
+
+            self.controller.solenoid.beep(duration=0.25, repeats=4)
+            sys.exit()
+
+        except Exception as e:
+            self.logger.log_line(f"\n[ALGORITHM ERROR] Error while starting algorithm: {algorithm}."
+                                 f"\nError message: {e}",
+                                 verbose=True)
+            sys.exit()
 
         try:
             while True:


### PR DESCRIPTION
This should improve the readibility of errors when using the GreenonGreen class. Previously errors were not caught effectively and descriptive messages were not provided.

Part of fix to #104 