### PR TITLE
Add usb camera option

### DIFF
--- a/config/DAY_SENSITIVITY_1.ini
+++ b/config/DAY_SENSITIVITY_1.ini
@@ -31,11 +31,12 @@ image_loop_time = 5
 resolution_width = 416
 resolution_height = 320
 exp_compensation = -2
-# camera_source can be:
+# camera_type can be:
 #   rpi   -> force Pi camera (PiCamera2/legacy if available)
 #   usb   -> force USB/webcam (skip PiCamera2 entirely)
 #   auto  -> prefer Pi camera on Pi, else USB
-camera_source = rpi
+# note: only used on Linux devices!
+camera_type = rpi
 
 [GreenOnGreen]
 # parameters related to green-on-green detection

--- a/config/DAY_SENSITIVITY_1.ini
+++ b/config/DAY_SENSITIVITY_1.ini
@@ -36,7 +36,7 @@ exp_compensation = -2
 #   usb   -> force USB/webcam (skip PiCamera2 entirely)
 #   auto  -> prefer Pi camera on Pi, else USB
 # note: only used on Linux devices!
-camera_type = rpi
+camera_type = auto
 
 [GreenOnGreen]
 # parameters related to green-on-green detection

--- a/config/DAY_SENSITIVITY_1.ini
+++ b/config/DAY_SENSITIVITY_1.ini
@@ -31,6 +31,11 @@ image_loop_time = 5
 resolution_width = 416
 resolution_height = 320
 exp_compensation = -2
+# camera_source can be:
+#   rpi   -> force Pi camera (PiCamera2/legacy if available)
+#   usb   -> force USB/webcam (skip PiCamera2 entirely)
+#   auto  -> prefer Pi camera on Pi, else USB
+camera_source = rpi
 
 [GreenOnGreen]
 # parameters related to green-on-green detection

--- a/config/DAY_SENSITIVITY_2.ini
+++ b/config/DAY_SENSITIVITY_2.ini
@@ -31,11 +31,12 @@ image_loop_time = 5
 resolution_width = 640
 resolution_height = 480
 exp_compensation = -2
-# camera_source can be:
+# camera_type can be:
 #   rpi   -> force Pi camera (PiCamera2/legacy if available)
 #   usb   -> force USB/webcam (skip PiCamera2 entirely)
 #   auto  -> prefer Pi camera on Pi, else USB
-camera_source = rpi
+# note: only used on Linux devices!
+camera_type = rpi
 
 [GreenOnGreen]
 # parameters related to green-on-green detection

--- a/config/DAY_SENSITIVITY_2.ini
+++ b/config/DAY_SENSITIVITY_2.ini
@@ -31,6 +31,11 @@ image_loop_time = 5
 resolution_width = 640
 resolution_height = 480
 exp_compensation = -2
+# camera_source can be:
+#   rpi   -> force Pi camera (PiCamera2/legacy if available)
+#   usb   -> force USB/webcam (skip PiCamera2 entirely)
+#   auto  -> prefer Pi camera on Pi, else USB
+camera_source = rpi
 
 [GreenOnGreen]
 # parameters related to green-on-green detection

--- a/config/DAY_SENSITIVITY_2.ini
+++ b/config/DAY_SENSITIVITY_2.ini
@@ -34,9 +34,9 @@ exp_compensation = -2
 # camera_type can be:
 #   rpi   -> force Pi camera (PiCamera2/legacy if available)
 #   usb   -> force USB/webcam (skip PiCamera2 entirely)
-#   auto  -> prefer Pi camera on Pi, else USB
+#   auto  -> prefer Pi camera on Pi, else USB - DEFAULT
 # note: only used on Linux devices!
-camera_type = rpi
+camera_type = auto
 
 [GreenOnGreen]
 # parameters related to green-on-green detection

--- a/config/DAY_SENSITIVITY_3.ini
+++ b/config/DAY_SENSITIVITY_3.ini
@@ -36,7 +36,7 @@ exp_compensation = -2
 #   usb   -> force USB/webcam (skip PiCamera2 entirely)
 #   auto  -> prefer Pi camera on Pi, else USB
 # note: only used on Linux devices!
-camera_type = rpi
+camera_type = auto
 
 [GreenOnGreen]
 # parameters related to green-on-green detection

--- a/config/DAY_SENSITIVITY_3.ini
+++ b/config/DAY_SENSITIVITY_3.ini
@@ -31,6 +31,12 @@ image_loop_time = 5
 resolution_width = 416
 resolution_height = 320
 exp_compensation = -2
+# camera_type can be:
+#   rpi   -> force Pi camera (will use PiCamera2/or legacy picamera if available)
+#   usb   -> force USB/webcam (skip PiCamera2 entirely)
+#   auto  -> prefer Pi camera on Pi, else USB
+# note: only used on Linux devices!
+camera_type = rpi
 
 [GreenOnGreen]
 # parameters related to green-on-green detection

--- a/owl.py
+++ b/owl.py
@@ -4,6 +4,7 @@ import sys
 
 import logging
 import argparse
+import platform
 import time
 from datetime import datetime
 from multiprocessing import Process, Value
@@ -282,9 +283,10 @@ class Owl:
 
         self.frame_width = None
         self.frame_height = None
+        self.camera_type = self.config.get('Camera', 'camera_type')
 
         try:
-            self.cam = self.setup_media_source(input_file_or_directory)
+            self.cam = self.setup_media_source(input_file_or_directory, camera_type=self.camera_type)
             self.logger.info('Media source successfully set up...')
             time.sleep(1.0)
 
@@ -606,7 +608,7 @@ class Owl:
 
         self.logger.info(f"[INFO] Configuration saved to {new_config_path}")
 
-    def setup_media_source(self, input_file_or_directory):
+    def setup_media_source(self, input_file_or_directory, camera_type='rpi'):
         """
         Configure and initialize the appropriate media source (camera or media file/directory).
 
@@ -657,8 +659,12 @@ class Owl:
 
         # Set up camera if no file input specified
         try:
+            if platform.system() != "Linux":
+                camera_type = "windows-usb"
+
             media_source = VideoStream(resolution=self.resolution,
-                                       exp_compensation=self.exp_compensation)
+                                       exp_compensation=self.exp_compensation,
+                                       camera_type=camera_type)
             media_source.start()
 
             self.frame_width = media_source.frame_width

--- a/owl_setup.sh
+++ b/owl_setup.sh
@@ -79,26 +79,100 @@ reload_bashrc() {
 check_camera_connection() {
   echo -e "${GREEN}[INFO] Checking for connected cameras...${NC}"
 
-  # 1 — Detect Raspberry Pi MIPI camera via libcamera
-  if rpicam-hello --list-cameras 2>&1 | grep -v "No cameras available" >/dev/null; then
-    echo -e "${GREEN}[INFO] Raspberry Pi CSI camera detected.${NC}"
-    STATUS_CAMERA="${TICK}"
-    return 0
+  # 1 — Detect Raspberry Pi CSI camera via libcamera
+  if command -v rpicam-hello >/dev/null 2>&1; then
+    if rpicam-hello --list-cameras 2>&1 | grep -qv "No cameras available"; then
+      echo -e "${GREEN}[INFO] Raspberry Pi CSI camera detected.${NC}"
+      CAMERA_MODE="rpi"
+      STATUS_CAMERA="${TICK}"
+      return 0
+    fi
   fi
 
   # 2 — Detect USB camera
-  if ls /dev/video0 >/dev/null 2>&1; then
-    echo -e "${ORANGE}[WARNING] No CSI camera detected; USB webcam found at /dev/video0.${NC}"
-    echo -e "${ORANGE}[WARNING] System will attempt webcam mode.${NC}"
-    STATUS_CAMERA="${TICK}"
-    return 0
+  if command -v v4l2-ctl >/dev/null 2>&1 && [[ -e /dev/video0 ]]; then
+    # basic sanity check — camera responds
+    if v4l2-ctl -d /dev/video0 --all >/dev/null 2>&1; then
+      echo -e "${GREEN}[INFO] USB webcam detected at /dev/video0.${NC}"
+      CAMERA_MODE="usb"
+      STATUS_CAMERA="${TICK}"
+      return 0
+    fi
   fi
 
   # 3 — Neither exists, warn but continue install
-  echo -e "${RED}[WARNING] No camera detected!${NC}"
-  echo -e "${RED}[WARNING] Installation will continue, but OWL will not run until a camera is connected.${NC}"
+  echo -e "${RED}[WARNING] No camera detected (no CSI or USB).${NC}"
+  echo -e "${RED}[WARNING] OWL will not run until a camera is present.${NC}"
+  CAMERA_MODE="none"
   STATUS_CAMERA="${CROSS}"
   return 0
+}
+
+# check to see if the camera works
+test_camera_functionality() {
+  local mode="$1"  # "rpi", "usb" or "none"
+  local test_cmd=""
+
+  echo -e "${GREEN}[INFO] Testing camera functionality (mode: ${mode})...${NC}"
+
+  if [[ "$mode" == "none" ]]; then
+    echo -e "${RED}[WARN] Skipping camera test: no camera detected.${NC}"
+    STATUS_CAMERA_TEST="${CROSS}"
+    ERROR_CAMERA_TEST="No camera detected"
+    return
+  fi
+
+  if [[ "$mode" == "usb" ]]; then
+    if ! command -v v4l2-ctl >/dev/null 2>&1; then
+      echo -e "${ORANGE}[WARN] v4l2-ctl not found. Install with: sudo apt install v4l-utils${NC}"
+      STATUS_CAMERA_TEST="${CROSS}"
+      ERROR_CAMERA_TEST="v4l2-ctl missing for USB camera test"
+      return
+    fi
+
+    if [[ ! -e /dev/video0 ]]; then
+      echo -e "${RED}[WARNING] /dev/video0 not found. USB camera not available.${NC}"
+      STATUS_CAMERA_TEST="${CROSS}"
+      ERROR_CAMERA_TEST="No /dev/video0 device"
+      return
+    fi
+
+    # Headless-safe: just query controls / capabilities
+    test_cmd="v4l2-ctl -d /dev/video0 --all"
+  else
+    # Default to Raspberry Pi CSI camera mode
+    if ! command -v rpicam-hello >/dev/null 2>&1; then
+      echo -e "${ORANGE}[WARN] rpicam-hello not found. Skipping Pi camera test.${NC}"
+      STATUS_CAMERA_TEST="${CROSS}"
+      ERROR_CAMERA_TEST="rpicam-hello missing"
+      return
+    fi
+
+    # Headless-safe: no preview, short timeout
+    test_cmd="rpicam-hello --nopreview --timeout 200"
+  fi
+
+  # First test
+  ${test_cmd} > /dev/null 2>&1
+  if [ $? -ne 0 ]; then
+    echo -e "${RED}[WARNING] Camera test failed. Running full system upgrade to resolve potential issues...${NC}"
+    sudo apt full-upgrade -y
+    check_status "Full system upgrade" "FULL_UPGRADE"
+
+    echo -e "${GREEN}[INFO] Retesting camera after full upgrade...${NC}"
+    ${test_cmd} > /dev/null 2>&1
+    if [ $? -ne 0 ]; then
+      echo -e "${RED}[CRITICAL ERROR] Camera still not working after full upgrade. Please log an issue: https://github.com/geezacoleman/OpenWeedLocator/issues${NC}"
+      STATUS_CAMERA_TEST="${CROSS}"
+      ERROR_CAMERA_TEST="Camera test failed in mode '${mode}'"
+    else
+      echo -e "${GREEN}[INFO] Camera test passed after full upgrade.${NC}"
+      STATUS_CAMERA_TEST="${TICK}"
+    fi
+  else
+    echo -e "${GREEN}[INFO] Camera is working correctly.${NC}"
+    STATUS_CAMERA_TEST="${TICK}"
+  fi
 }
 
 
@@ -113,26 +187,7 @@ check_camera_connection
 
 # Step 3: Test camera functionality
 echo -e "${GREEN}[INFO] Testing camera functionality...${NC}"
-rpicam-hello > /dev/null 2>&1
-if [ $? -ne 0 ]; then
-  echo -e "${RED}[WARNING] Camera test failed. Running full system upgrade to resolve potential issues...${NC}"
-  sudo apt full-upgrade -y
-  check_status "Full system upgrade" "FULL_UPGRADE"
 
-  echo -e "${GREEN}[INFO] Retesting camera after full upgrade...${NC}"
-  rpicam-hello > /dev/null 2>&1
-  if [ $? -ne 0 ]; then
-    echo -e "${RED}[CRITICAL ERROR] Camera still not working after full upgrade. Please log an issue: https://github.com/geezacoleman/OpenWeedLocator/issues${NC}"
-    STATUS_CAMERA_TEST="${CROSS}"
-    ERROR_CAMERA_TEST="No camera detected"
-  else
-    echo -e "${GREEN}[INFO] Camera test passed after full upgrade.${NC}"
-    STATUS_CAMERA_TEST="${TICK}"
-  fi
-else
-  echo -e "${GREEN}[INFO] Camera is working correctly.${NC}"
-  STATUS_CAMERA_TEST="${TICK}"
-fi
 
 # Step 4: Free up space
 echo -e "${GREEN}[INFO] Freeing up space by removing unnecessary packages...${NC}"

--- a/owl_setup.sh
+++ b/owl_setup.sh
@@ -77,18 +77,30 @@ reload_bashrc() {
 
 # Function to check if the camera is detected
 check_camera_connection() {
-  echo -e "${GREEN}[INFO] Checking for connected Raspberry Pi camera...${NC}"
-  while true; do
-    if rpicam-hello --list-cameras 2>&1 | grep -q "No cameras available"; then
-      echo -e "${RED}[ERROR] No camera detected!${NC}"
-      read -p "Please connect a Raspberry Pi camera and press Enter to retry..." temp
-    else
-      echo -e "${GREEN}[INFO] Camera detected successfully.${NC}"
-      STATUS_CAMERA="${TICK}"
-      return 0
-    fi
-  done
+  echo -e "${GREEN}[INFO] Checking for connected cameras...${NC}"
+
+  # 1 — Detect Raspberry Pi MIPI camera via libcamera
+  if rpicam-hello --list-cameras 2>&1 | grep -v "No cameras available" >/dev/null; then
+    echo -e "${GREEN}[INFO] Raspberry Pi CSI camera detected.${NC}"
+    STATUS_CAMERA="${TICK}"
+    return 0
+  fi
+
+  # 2 — Detect USB camera
+  if ls /dev/video0 >/dev/null 2>&1; then
+    echo -e "${ORANGE}[WARNING] No CSI camera detected; USB webcam found at /dev/video0.${NC}"
+    echo -e "${ORANGE}[WARNING] System will attempt webcam mode.${NC}"
+    STATUS_CAMERA="${TICK}"
+    return 0
+  fi
+
+  # 3 — Neither exists, warn but continue install
+  echo -e "${RED}[WARNING] No camera detected!${NC}"
+  echo -e "${RED}[WARNING] Installation will continue, but OWL will not run until a camera is connected.${NC}"
+  STATUS_CAMERA="${CROSS}"
+  return 0
 }
+
 
 # Step 1: Perform a normal system update and upgrade
 echo -e "${GREEN}[INFO] Updating and upgrading the system...${NC}"

--- a/utils/config_manager.py
+++ b/utils/config_manager.py
@@ -7,6 +7,7 @@ import utils.error_manager as errors
 
 logger = logging.getLogger(__name__)
 
+
 class ConfigValidator:
     """Validates OWL configuration files"""
 
@@ -51,9 +52,17 @@ class ConfigValidator:
                 }
             }
         },
+        'Visualisation': {
+            'required_keys': {'image_loop_time'},
+            'optional_keys': set()
+        },
         'Camera': {
             'required_keys': {'resolution_width', 'resolution_height'},
-            'optional_keys': {'exp_compensation'}
+            'optional_keys': {'exp_compensation', 'camera_type'}
+        },
+        'GreenOnGreen': {
+            'required_keys': {'model_path', 'confidence'},
+            'optional_keys': {'class_filter_id'}
         },
         'GreenOnBrown': {
             'required_keys': {
@@ -68,8 +77,11 @@ class ConfigValidator:
             'optional_keys': {'sample_frequency', 'disable_detection', 'log_fps', 'camera_name'}
         },
         'Relays': {
-            'required_keys': {'0', '1', '2', '3'},
-            'optional_keys': set()
+            # Required keys are dynamically determined by relay_num in [System]
+            # Validation is handled by validate_relays() method
+            'required_keys': set(),
+            'optional_keys': set(),
+            'dynamic_keys': True  # Flag to indicate keys are validated elsewhere
         }
     }
 
@@ -89,19 +101,48 @@ class ConfigValidator:
         'resolution_height': ('int', 1, None),
         # Camera settings
         'exp_compensation': ('float', -10, 10),
-        # Detection confidence
+        # Detection settings
         'confidence': ('float', 0, 1),
+        'min_detection_area': ('int', 1, None),
         # GPIO pins
         'switch_pin': ('pin', 1, 40),
         'detection_mode_pin_up': ('pin', 1, 40),
         'detection_mode_pin_down': ('pin', 1, 40),
         'recording_pin': ('pin', 1, 40),
         'sensitivity_pin': ('pin', 1, 40),
+        # Visualisation
+        'image_loop_time': ('int', 1, None),
+        # DataCollection
+        'sample_frequency': ('int', 1, None),
+        # Boolean fields
+        'sample_images': ('bool', None, None),
+        'disable_detection': ('bool', None, None),
+        'log_fps': ('bool', None, None),
+        'invert_hue': ('bool', None, None),
     }
 
     VALID_ALGORITHMS = {'exg', 'exgr', 'maxg', 'nexg', 'exhsv', 'hsv', 'gndvi', 'gog'}
     VALID_CONTROLLER_TYPES = {'none', 'ute', 'advanced'}
     VALID_SWITCH_PURPOSES = {'recording', 'sensitivity'}
+    VALID_CAMERA_TYPES = {'rpi', 'usb', 'auto'}
+    VALID_SAMPLE_METHODS = {'bbox', 'square', 'whole'}
+    VALID_BOOLEANS = {'true', 'false', '1', '0', 'yes', 'no', 'on', 'off'}
+
+    # Valid Raspberry Pi GPIO pins (BOARD numbering)
+    # Excludes: power pins (1, 2, 4, 17), ground pins (6, 9, 14, 20, 25, 30, 34, 39),
+    # and I2C EEPROM reserved pins (27, 28)
+    VALID_GPIO_PINS = {
+        3, 5, 7, 8, 10, 11, 12, 13, 15, 16, 18, 19,
+        21, 22, 23, 24, 26, 29, 31, 32, 33, 35, 36, 37, 38, 40
+    }
+
+    # Human-readable descriptions for invalid pins
+    RESERVED_PIN_DESCRIPTIONS = {
+        1: '3.3V Power', 2: '5V Power', 4: '5V Power', 17: '3.3V Power',
+        6: 'Ground', 9: 'Ground', 14: 'Ground', 20: 'Ground',
+        25: 'Ground', 30: 'Ground', 34: 'Ground', 39: 'Ground',
+        27: 'I2C EEPROM (ID_SD)', 28: 'I2C EEPROM (ID_SC)'
+    }
 
     # to check for valid ranges
     THRESHOLD_PAIRS = [
@@ -178,6 +219,36 @@ class ConfigValidator:
         return True, {}
 
     @classmethod
+    def validate_camera_type(cls, config: ConfigParser) -> Tuple[bool, Dict[str, Dict[str, str]]]:
+        """Validate camera type selection."""
+        if not config.has_option('Camera', 'camera_type'):
+            return True, {}  # Optional field, skip if not present
+
+        camera_type = config.get('Camera', 'camera_type', fallback='').lower()
+
+        if camera_type not in cls.VALID_CAMERA_TYPES:
+            return False, {'Camera': {
+                'camera_type': f'Invalid camera type. Must be one of: {", ".join(sorted(cls.VALID_CAMERA_TYPES))}'
+            }}
+
+        return True, {}
+
+    @classmethod
+    def validate_sample_method(cls, config: ConfigParser) -> Tuple[bool, Dict[str, Dict[str, str]]]:
+        """Validate sample method selection."""
+        if not config.has_option('DataCollection', 'sample_method'):
+            return True, {}  # Will be caught by required key validation
+
+        sample_method = config.get('DataCollection', 'sample_method', fallback='').lower()
+
+        if sample_method not in cls.VALID_SAMPLE_METHODS:
+            return False, {'DataCollection': {
+                'sample_method': f'Invalid sample method. Must be one of: {", ".join(sorted(cls.VALID_SAMPLE_METHODS))}'
+            }}
+
+        return True, {}
+
+    @classmethod
     def validate_thresholds(cls, config: ConfigParser) -> Tuple[bool, Dict[str, Dict[str, str]]]:
         """
         Validate threshold relationships and detection ranges.
@@ -244,8 +315,29 @@ class ConfigValidator:
         return not bool(threshold_errors), threshold_errors
 
     @classmethod
-    def validate_value(cls, key: str, value: str, used_pins: Set[int]) -> Tuple[bool, str]:
+    def validate_value(cls, key: str, value: str, used_pins: Set[int], relay_pins: Set[int], section: str = '') -> \
+    Tuple[bool, str]:
         """Validate a single config value."""
+
+        # Handle relay pins dynamically (any integer key in Relays section)
+        if section == 'Relays':
+            try:
+                relay_id = int(key)  # Validate key is an integer
+                pin_val = int(value)
+                if pin_val < 1 or pin_val > 40:
+                    return False, f"Relay pin must be between 1 and 40"
+                if pin_val not in cls.VALID_GPIO_PINS:
+                    desc = cls.RESERVED_PIN_DESCRIPTIONS.get(pin_val, 'Reserved/Invalid')
+                    return False, f"Pin {pin_val} is not a valid GPIO pin ({desc})"
+                if pin_val in relay_pins:
+                    return False, f"Pin {pin_val} is already assigned to another relay"
+                if pin_val in used_pins:
+                    return False, f"Pin {pin_val} is already in use by a controller function"
+                relay_pins.add(pin_val)
+                return True, ""
+            except ValueError:
+                return False, f"Relay key must be an integer and pin value must be a valid number"
+
         if key not in cls.VALUE_VALIDATORS:
             return True, ""
 
@@ -266,14 +358,23 @@ class ConfigValidator:
                 if max_val is not None and val > max_val:
                     return False, f"Value must be <= {max_val}"
 
+            elif val_type == 'bool':
+                if value.lower() not in cls.VALID_BOOLEANS:
+                    return False, f"Must be a boolean value (true/false, yes/no, 1/0, on/off)"
+
             elif val_type == 'pin':
                 val = int(value)
                 if min_val is not None and val < min_val:
                     return False, f"Pin must be >= {min_val}"
                 if max_val is not None and val > max_val:
                     return False, f"Pin must be <= {max_val}"
+                if val not in cls.VALID_GPIO_PINS:
+                    desc = cls.RESERVED_PIN_DESCRIPTIONS.get(val, 'Reserved/Invalid')
+                    return False, f"Pin {val} is not a valid GPIO pin ({desc})"
                 if val in used_pins:
-                    return False, f"Pin {val} is already in use"
+                    return False, f"Pin {val} is already in use by another controller function"
+                if val in relay_pins:
+                    return False, f"Pin {val} is already in use by a relay"
                 used_pins.add(val)
 
         except ValueError:
@@ -342,7 +443,8 @@ class ConfigValidator:
     def load_and_validate_config(cls, config_path: Path) -> ConfigParser:
         """Load and validate configuration file."""
         config = ConfigParser()
-        used_pins = set()
+        used_pins: Set[int] = set()
+        relay_pins: Set[int] = set()
         validation_errors = {}
 
         # File existence and parsing must still raise immediately
@@ -378,27 +480,54 @@ class ConfigValidator:
         if not is_valid:
             validation_errors.update(algorithm_errors)
 
+        # Validate camera type
+        is_valid, camera_errors = cls.validate_camera_type(config)
+        if not is_valid:
+            validation_errors.update(camera_errors)
+
+        # Validate sample method
+        is_valid, sample_errors = cls.validate_sample_method(config)
+        if not is_valid:
+            validation_errors.update(sample_errors)
+
         # Threshold validation
         is_valid, threshold_errors = cls.validate_thresholds(config)
         if not is_valid:
             validation_errors.update(threshold_errors)
 
         # Check required sections
-        missing_sections = set(working_config.keys()) - set(config.sections())
+        # Filter out 'type_specific' from Controller when checking sections
+        required_sections = {k for k in working_config.keys() if k != 'type_specific'}
+        missing_sections = required_sections - set(config.sections())
         if missing_sections:
             validation_errors['missing_sections'] = {
                 'sections': f"Missing required sections: {', '.join(missing_sections)}"
             }
 
-        # Validate sections and values
-        for section in config.sections():
+        # Process Relays section first to collect relay pins before validating controller pins
+        if 'Relays' in config.sections():
             section_errors = {}
-            for key, value in config[section].items():
-                is_valid, error_msg = cls.validate_value(key, value, used_pins)
+            for key, value in config['Relays'].items():
+                is_valid, error_msg = cls.validate_value(key, value, used_pins, relay_pins, 'Relays')
                 if not is_valid:
                     section_errors[key] = value + f" - {error_msg}"
             if section_errors:
-                validation_errors[section] = section_errors
+                validation_errors['Relays'] = section_errors
+
+        # Validate remaining sections and values
+        for section in config.sections():
+            if section == 'Relays':
+                continue  # Already processed above
+            section_errors = {}
+            for key, value in config[section].items():
+                is_valid, error_msg = cls.validate_value(key, value, used_pins, relay_pins, section)
+                if not is_valid:
+                    section_errors[key] = value + f" - {error_msg}"
+            if section_errors:
+                if section in validation_errors:
+                    validation_errors[section].update(section_errors)
+                else:
+                    validation_errors[section] = section_errors
 
         # Validate relay configuration
         is_valid, relay_errors, relay_warnings = cls.validate_relays(config)
@@ -411,12 +540,17 @@ class ConfigValidator:
 
         # Check required keys in each section
         for section, requirements in working_config.items():
+            # Skip type_specific as it's not a real section
+            if section == 'type_specific':
+                continue
+            if not isinstance(requirements, dict) or 'required_keys' not in requirements:
+                continue
             if section not in config.sections():
                 continue  # Skip if section is missing - we've already recorded this error
 
             config_keys = set(config[section].keys())
             required_keys = {k.lower() for k in requirements['required_keys']}
-            optional_keys = {k.lower() for k in requirements['optional_keys']}
+            optional_keys = {k.lower() for k in requirements.get('optional_keys', set())}
 
             missing_keys = required_keys - config_keys
             if missing_keys:
@@ -425,6 +559,10 @@ class ConfigValidator:
                 validation_errors[section].update({
                     k: "Required key missing" for k in missing_keys
                 })
+
+            # Skip sections with dynamic keys (like Relays)
+            if requirements.get('dynamic_keys', False):
+                continue
 
             unknown_keys = config_keys - (required_keys | optional_keys)
             if unknown_keys:

--- a/utils/video_manager.py
+++ b/utils/video_manager.py
@@ -31,13 +31,12 @@ class WebcamStream:
         self.IS_PI = pi
 
         if self.IS_PI:
-            # On Pi/Linux, map integer indices to /dev/videoN and force V4L2
             if isinstance(src, int):
                 device = f"/dev/video{src}"
             else:
                 device = src
             self.logger.info(f"[INFO] Opening webcam via V4L2 on device {device}")
-            self.stream = cv2.VideoCapture(device, cv2.CAP_V4L2)
+            self.stream = cv2.VideoCapture(device)
         else:
             # Cross-platform default (Windows, macOS, generic Linux)
             self.logger.info(f"[INFO] Opening webcam via default backend on source {src}")

--- a/utils/video_manager.py
+++ b/utils/video_manager.py
@@ -1,26 +1,49 @@
 import cv2
 import time
+import platform
 
 from threading import Thread, Event, Condition, Lock
 from utils.log_manager import LogManager
 
 # determine availability of picamera versions
+PICAMERA_VERSION = None
+
 try:
     from picamera.array import PiRGBArray
     from picamera import PiCamera
-    PICAMERA_VERSION = 'legacy'
 
-except Exception as e:
-    PICAMERA_VERSION = None
+    PICAMERA_VERSION = 'legacy'
+except ImportError:
+    pass
 
 try:
     from picamera2 import Picamera2
     from libcamera import Transform
     import libcamera
-    PICAMERA_VERSION = 'picamera2'
 
-except Exception as e:
-    PICAMERA_VERSION = None
+    PICAMERA_VERSION = 'picamera2'
+except ImportError:
+    pass
+
+
+def is_raspberry_pi() -> bool:
+    """Check if running on a Raspberry Pi."""
+    try:
+        with open('/proc/device-tree/model', 'r') as f:
+            model = f.read().lower()
+            return 'raspberry pi' in model
+    except (FileNotFoundError, IOError):
+        return False
+
+
+def get_platform_info() -> dict:
+    """Get platform information for camera selection."""
+    return {
+        'system': platform.system(),
+        'is_rpi': is_raspberry_pi(),
+        'picamera_version': PICAMERA_VERSION
+    }
+
 
 # class to support webcams
 class WebcamStream:
@@ -96,7 +119,10 @@ class WebcamStream:
 
     def stop(self):
         self.stop_event.set()
-        self.thread.join()
+        if self.thread.is_alive():
+            self.thread.join(timeout=2.0)
+        if self.stream.isOpened():
+            self.stream.release()
 
 
 class PiCamera2Stream:
@@ -214,13 +240,16 @@ class PiCamera2Stream:
             while not self.frame_available:
                 self.condition.wait()
 
-            while self.lock:
+            with self.lock:
                 self.frame_available = False
                 return self.frame
 
     def stop(self):
         self.stopped.set()
-        self.thread.join()
+        with self.condition:
+            self.condition.notify_all()  # Wake up any waiting threads
+        if hasattr(self, 'thread') and self.thread.is_alive():
+            self.thread.join(timeout=2.0)
         self.camera.stop()
         time.sleep(2)  # Allow time for the camera to be released properly
 
@@ -299,83 +328,159 @@ class PiCameraStream:
         self.stopped.set()
 
         # Wait for the thread to finish
-        self.thread.join()
+        if self.thread.is_alive():
+            self.thread.join(timeout=2.0)
 
 
 # overarching class to determine which stream to use
 class VideoStream:
-    def __init__(self, src=0, resolution=(416, 320), exp_compensation=-2, camera_type='rpi', **kwargs):
-        self.CAMERA_VERSION = PICAMERA_VERSION if PICAMERA_VERSION is not None else 'webcam'
-        self.CAMERA_TYPE = camera_type
+    """
+    Unified video stream interface that automatically selects the appropriate
+    camera backend based on platform and configuration.
+
+    Camera type options:
+        - 'rpi': Force Raspberry Pi camera (PiCamera2 or legacy)
+        - 'usb': Force USB webcam
+        - 'auto': Auto-detect best available camera (Pi camera preferred on RPi)
+
+    On non-Linux systems (Windows/Mac), automatically uses USB webcam regardless
+    of camera_type setting.
+    """
+
+    def __init__(self, src=0, resolution=(416, 320), exp_compensation=-2, camera_type='auto', **kwargs):
         self.logger = LogManager.get_logger(__name__)
-        self.logger.info(f"[INFO] Initial camera backend selection: {self.CAMERA_VERSION} (src={src})")
+        self.platform_info = get_platform_info()
         self.frame_height = None
         self.frame_width = None
+        self.stream = None
 
-        if self.CAMERA_TYPE == 'rpi':
-            if self.CAMERA_VERSION == 'picamera2':
-                try:
-                    self.stream = PiCamera2Stream(src=src,
-                                                  resolution=resolution,
-                                                  exp_compensation=exp_compensation,
-                                                  **kwargs)
-                except Exception as e:
-                    self.logger.warning(
-                        f"PiCamera2Stream failed with RPI camera_type ({e})",
-                        exc_info=True
-                    )
+        # Resolve effective camera type based on platform
+        effective_camera_type = self._resolve_camera_type(camera_type)
+        self.logger.info(
+            f"Camera selection: requested='{camera_type}', effective='{effective_camera_type}', "
+            f"platform={self.platform_info['system']}, is_rpi={self.platform_info['is_rpi']}, "
+            f"picamera_version={self.platform_info['picamera_version']}"
+        )
 
-            elif self.CAMERA_VERSION == 'legacy':
-                try:
-                    self.stream = PiCameraStream(resolution=resolution,
-                                                 exp_compensation=exp_compensation,
-                                                 **kwargs)
-                except Exception as e:
-                    self.logger.warning(
-                        f"PiCameraStream failed ({e})",
-                        exc_info=True
-                    )
+        # Initialize the appropriate stream
+        init_error = None
 
-        elif self.CAMERA_TYPE == 'usb':
-            try:
-                self.stream = WebcamStream(src="/dev/video0", resolution=resolution)
-            except Exception as e:
-                self.logger.warning(
-                    f"RPI-USB Webcam Stream failed ({e})",
-                    exc_info=True
-                )
-        elif self.CAMERA_TYPE == 'windows-usb':
-            try:
-                self.stream = WebcamStream(src=0, resolution=resolution)
-            except Exception as e:
-                self.logger.warning(
-                    f"WINDOWS-USB Webcam Stream failed ({e})",
-                    exc_info=True
-                )
+        if effective_camera_type == 'rpi':
+            init_error = self._init_rpi_camera(src, resolution, exp_compensation, **kwargs)
+
+        elif effective_camera_type == 'usb':
+            init_error = self._init_usb_camera(src, resolution)
+
         else:
-            self.logger.error(
-                f"[ERROR] Unsupported camera version: {self.CAMERA_TYPE}"
-            )
-            raise ValueError(f"[ERROR] Unsupported camera version: {self.CAMERA_TYPE}")
+            # This shouldn't happen if _resolve_camera_type works correctly
+            raise ValueError(f"Unsupported camera type: {effective_camera_type}")
 
-        # set the image dimensions directly from the frame streamed
+        # Verify stream was initialized
+        if self.stream is None:
+            error_msg = f"Failed to initialize any camera stream"
+            if init_error:
+                error_msg += f": {init_error}"
+            self.logger.error(error_msg)
+            raise RuntimeError(error_msg)
+
+        # Set frame dimensions from the initialized stream
         self.frame_width = self.stream.frame_width
         self.frame_height = self.stream.frame_height
 
+    def _resolve_camera_type(self, camera_type: str) -> str:
+        """
+        Resolve the effective camera type based on platform.
+
+        Note: 'auto' makes a single selection based on platform detection - it does NOT
+        attempt fallback between camera types, as this can cause resource locking issues
+        (e.g., libcamera holding /dev/video* devices after a failed Pi camera init).
+        """
+        camera_type = camera_type.lower().strip()
+
+        # Non-Linux systems always use USB
+        if self.platform_info['system'] != 'Linux':
+            if camera_type == 'rpi':
+                self.logger.warning(
+                    f"RPi camera requested but running on {self.platform_info['system']}. "
+                    f"Using USB webcam instead."
+                )
+            return 'usb'
+
+        # Handle 'auto' - make a single decision, no fallback attempts
+        if camera_type == 'auto':
+            if self.platform_info['is_rpi'] and self.platform_info['picamera_version']:
+                self.logger.info("Auto mode on RPi with picamera available: selecting RPi camera")
+                return 'rpi'
+            else:
+                self.logger.info("Auto mode: selecting USB camera (not RPi or no picamera library)")
+                return 'usb'
+
+        return camera_type
+
+    def _init_rpi_camera(self, src, resolution, exp_compensation, **kwargs) -> str | None:
+        """Initialize Raspberry Pi camera. Returns error message on failure, None on success."""
+        picamera_version = self.platform_info['picamera_version']
+
+        if picamera_version is None:
+            msg = "No PiCamera library available (neither picamera2 nor legacy picamera)"
+            self.logger.error(msg)
+            return msg
+
+        if picamera_version == 'picamera2':
+            try:
+                self.stream = PiCamera2Stream(
+                    src=src,
+                    resolution=resolution,
+                    exp_compensation=exp_compensation,
+                    **kwargs
+                )
+                return None
+            except Exception as e:
+                self.logger.error(f"PiCamera2Stream initialization failed: {e}", exc_info=True)
+                return str(e)
+
+        elif picamera_version == 'legacy':
+            try:
+                self.stream = PiCameraStream(
+                    resolution=resolution,
+                    exp_compensation=exp_compensation,
+                    **kwargs
+                )
+                return None
+            except Exception as e:
+                self.logger.error(f"PiCameraStream initialization failed: {e}", exc_info=True)
+                return str(e)
+
+        return f"Unknown picamera version: {picamera_version}"
+
+    def _init_usb_camera(self, src, resolution) -> str | None:
+        """Initialize USB webcam. Returns error message on failure, None on success."""
+        # Determine video source based on platform
+        if self.platform_info['system'] == 'Linux':
+            video_src = src if isinstance(src, str) else '/dev/video0'
+        else:
+            video_src = src if isinstance(src, int) else 0
+
+        try:
+            self.stream = WebcamStream(src=video_src, resolution=resolution)
+            return None
+        except Exception as e:
+            self.logger.error(f"WebcamStream initialization failed: {e}", exc_info=True)
+            return str(e)
+
     def start(self):
-        # start the threaded video stream
+        """Start the threaded video stream."""
         return self.stream.start()
 
     def update(self):
-        # grab the next frame from the stream
+        """Grab the next frame from the stream."""
         self.stream.update()
 
     def read(self):
-        # return the current frame
+        """Return the current frame."""
         return self.stream.read()
 
     def stop(self):
-        # stop the thread and release any resources
-        self.stream.stop()
-
-
+        """Stop the thread and release any resources."""
+        if self.stream:
+            self.stream.stop()

--- a/utils/video_manager.py
+++ b/utils/video_manager.py
@@ -24,11 +24,24 @@ except Exception as e:
 
 # class to support webcams
 class WebcamStream:
-    def __init__(self, src=0, resolution=(640, 480), framerate=30):
+    def __init__(self, src=0, resolution=(640, 480), framerate=30, pi=False):
         self.logger = LogManager.get_logger(__name__)
         self.name = "WebcamStream"
         self.logger.info(f'Camera type: {self.name}')
-        self.stream = cv2.VideoCapture(src)
+        self.IS_PI = pi
+
+        if self.IS_PI:
+            # On Pi/Linux, map integer indices to /dev/videoN and force V4L2
+            if isinstance(src, int):
+                device = f"/dev/video{src}"
+            else:
+                device = src
+            self.logger.info(f"[INFO] Opening webcam via V4L2 on device {device}")
+            self.stream = cv2.VideoCapture(device, cv2.CAP_V4L2)
+        else:
+            # Cross-platform default (Windows, macOS, generic Linux)
+            self.logger.info(f"[INFO] Opening webcam via default backend on source {src}")
+            self.stream = cv2.VideoCapture(src)
 
         # Check if the stream opened successfully
         if not self.stream.isOpened():
@@ -321,7 +334,7 @@ class VideoStream:
                     f"PiCamera2Stream failed ({e}); falling back to USB webcam.",
                     exc_info=True
                 )
-                self.stream = WebcamStream(src=src, resolution=resolution)
+                self.stream = WebcamStream(src=src, resolution=resolution, pi=True)
 
         elif self.CAMERA_VERSION == 'legacy':
             try:
@@ -333,9 +346,10 @@ class VideoStream:
                     f"PiCameraStream failed ({e}); falling back to USB webcam.",
                     exc_info=True
                 )
-                self.stream = WebcamStream(src=src, resolution=resolution)
+                self.stream = WebcamStream(src=src, resolution=resolution, pi=True)
+
         elif self.CAMERA_VERSION == 'webcam':
-            self.stream = WebcamStream(src=src, resolution=resolution)
+            self.stream = WebcamStream(src=src, resolution=resolution, pi=False)
 
         else:
             self.logger.error(

--- a/utils/video_manager.py
+++ b/utils/video_manager.py
@@ -33,12 +33,13 @@ class WebcamStream:
         if self.IS_PI:
             src = "/dev/video0"
             self.logger.info(f"[INFO] Opening webcam via V4L2 on device {src}")
-            self.stream = cv2.VideoCapture("dev/video0")
+            self.stream = cv2.VideoCapture("/dev/video0", cv2.CAP_V4L2)
         else:
             # Cross-platform default (Windows, macOS, generic Linux)
             self.logger.info(f"[INFO] Opening webcam via default backend on source {src}")
             self.stream = cv2.VideoCapture(src)
 
+        time.sleep(1)
         # Check if the stream opened successfully
         if not self.stream.isOpened():
             self.stream.release()

--- a/utils/video_manager.py
+++ b/utils/video_manager.py
@@ -28,17 +28,9 @@ class WebcamStream:
         self.logger = LogManager.get_logger(__name__)
         self.name = "WebcamStream"
         self.logger.info(f'Camera type: {self.name}')
-        self.IS_PI = pi
-
-        if self.IS_PI:
-            src = "/dev/video0"
-            self.logger.info(f"[INFO] Opening webcam via V4L2 on device {src}")
-            self.stream = cv2.VideoCapture(0, cv2.CAP_V4L2)
-        else:
-            # Cross-platform default (Windows, macOS, generic Linux)
-            self.logger.info(f"[INFO] Opening webcam via default backend on source {src}")
-            self.stream = cv2.VideoCapture(src)
-
+        src = "/dev/video0"
+        self.stream = cv2.VideoCapture(src)
+        self.logger.info(f'SRC: {src}')
         time.sleep(1)
         # Check if the stream opened successfully
         if not self.stream.isOpened():

--- a/utils/video_manager.py
+++ b/utils/video_manager.py
@@ -33,7 +33,7 @@ class WebcamStream:
         if self.IS_PI:
             src = "/dev/video0"
             self.logger.info(f"[INFO] Opening webcam via V4L2 on device {src}")
-            self.stream = cv2.VideoCapture("/dev/video0")
+            self.stream = cv2.VideoCapture("dev/video0")
         else:
             # Cross-platform default (Windows, macOS, generic Linux)
             self.logger.info(f"[INFO] Opening webcam via default backend on source {src}")

--- a/utils/video_manager.py
+++ b/utils/video_manager.py
@@ -314,10 +314,11 @@ class VideoStream:
 
         if self.CAMERA_VERSION == 'picamera2':
             try:
-                self.stream = PiCamera2Stream(src=src,
-                                              resolution=resolution,
-                                              exp_compensation=exp_compensation,
-                                              **kwargs)
+                self.stream = WebcamStream(src=src, resolution=resolution, pi=True)
+               #self.stream = PiCamera2Stream(src=src,
+               #                              resolution=resolution,
+               #                              exp_compensation=exp_compensation,
+               #                              **kwargs)
             except Exception as e:
                 self.logger.warning(
                     f"PiCamera2Stream failed ({e}); falling back to USB webcam.",

--- a/utils/video_manager.py
+++ b/utils/video_manager.py
@@ -24,14 +24,13 @@ except Exception as e:
 
 # class to support webcams
 class WebcamStream:
-    def __init__(self, src=0, resolution=(640, 480), framerate=30, pi=False):
+    def __init__(self, src=0, resolution=(640, 480), framerate=30):
         self.logger = LogManager.get_logger(__name__)
         self.name = "WebcamStream"
         self.logger.info(f'Camera type: {self.name}')
-        src = "/dev/video0"
+
         self.stream = cv2.VideoCapture(src)
-        self.logger.info(f'SRC: {src}')
-        time.sleep(1)
+
         # Check if the stream opened successfully
         if not self.stream.isOpened():
             self.stream.release()
@@ -305,48 +304,59 @@ class PiCameraStream:
 
 # overarching class to determine which stream to use
 class VideoStream:
-    def __init__(self, src=0, resolution=(416, 320), exp_compensation=-2, **kwargs):
+    def __init__(self, src=0, resolution=(416, 320), exp_compensation=-2, camera_type='rpi', **kwargs):
         self.CAMERA_VERSION = PICAMERA_VERSION if PICAMERA_VERSION is not None else 'webcam'
+        self.CAMERA_TYPE = camera_type
         self.logger = LogManager.get_logger(__name__)
         self.logger.info(f"[INFO] Initial camera backend selection: {self.CAMERA_VERSION} (src={src})")
         self.frame_height = None
         self.frame_width = None
 
-        if self.CAMERA_VERSION == 'picamera2':
+        if self.CAMERA_TYPE == 'rpi':
+            if self.CAMERA_VERSION == 'picamera2':
+                try:
+                    self.stream = PiCamera2Stream(src=src,
+                                                  resolution=resolution,
+                                                  exp_compensation=exp_compensation,
+                                                  **kwargs)
+                except Exception as e:
+                    self.logger.warning(
+                        f"PiCamera2Stream failed with RPI camera_type ({e})",
+                        exc_info=True
+                    )
+
+            elif self.CAMERA_VERSION == 'legacy':
+                try:
+                    self.stream = PiCameraStream(resolution=resolution,
+                                                 exp_compensation=exp_compensation,
+                                                 **kwargs)
+                except Exception as e:
+                    self.logger.warning(
+                        f"PiCameraStream failed ({e})",
+                        exc_info=True
+                    )
+
+        elif self.CAMERA_TYPE == 'usb':
             try:
-                self.stream = WebcamStream(src=src, resolution=resolution, pi=True)
-               #self.stream = PiCamera2Stream(src=src,
-               #                              resolution=resolution,
-               #                              exp_compensation=exp_compensation,
-               #                              **kwargs)
+                self.stream = WebcamStream(src="/dev/video0", resolution=resolution)
             except Exception as e:
                 self.logger.warning(
-                    f"PiCamera2Stream failed ({e}); falling back to USB webcam.",
+                    f"RPI-USB Webcam Stream failed ({e})",
                     exc_info=True
                 )
-                time.sleep(3)
-                self.stream = WebcamStream(src=src, resolution=resolution, pi=True)
-
-        elif self.CAMERA_VERSION == 'legacy':
+        elif self.CAMERA_TYPE == 'windows-usb':
             try:
-                self.stream = PiCameraStream(resolution=resolution,
-                                             exp_compensation=exp_compensation,
-                                             **kwargs)
+                self.stream = WebcamStream(src=0, resolution=resolution)
             except Exception as e:
                 self.logger.warning(
-                    f"PiCameraStream failed ({e}); falling back to USB webcam.",
+                    f"WINDOWS-USB Webcam Stream failed ({e})",
                     exc_info=True
                 )
-                self.stream = WebcamStream(src=src, resolution=resolution, pi=True)
-
-        elif self.CAMERA_VERSION == 'webcam':
-            self.stream = WebcamStream(src=src, resolution=resolution, pi=False)
-
         else:
             self.logger.error(
-                f"[ERROR] Unsupported camera version: {self.CAMERA_VERSION}"
+                f"[ERROR] Unsupported camera version: {self.CAMERA_TYPE}"
             )
-            raise ValueError(f"[ERROR] Unsupported camera version: {self.CAMERA_VERSION}")
+            raise ValueError(f"[ERROR] Unsupported camera version: {self.CAMERA_TYPE}")
 
         # set the image dimensions directly from the frame streamed
         self.frame_width = self.stream.frame_width

--- a/utils/video_manager.py
+++ b/utils/video_manager.py
@@ -33,7 +33,7 @@ class WebcamStream:
         if self.IS_PI:
             src = "/dev/video0"
             self.logger.info(f"[INFO] Opening webcam via V4L2 on device {src}")
-            self.stream = cv2.VideoCapture("/dev/video0", cv2.CAP_V4L2)
+            self.stream = cv2.VideoCapture(0, cv2.CAP_V4L2)
         else:
             # Cross-platform default (Windows, macOS, generic Linux)
             self.logger.info(f"[INFO] Opening webcam via default backend on source {src}")

--- a/utils/video_manager.py
+++ b/utils/video_manager.py
@@ -330,6 +330,7 @@ class VideoStream:
                     f"PiCamera2Stream failed ({e}); falling back to USB webcam.",
                     exc_info=True
                 )
+                time.sleep(3)
                 self.stream = WebcamStream(src=src, resolution=resolution, pi=True)
 
         elif self.CAMERA_VERSION == 'legacy':

--- a/utils/video_manager.py
+++ b/utils/video_manager.py
@@ -24,27 +24,45 @@ except Exception as e:
 
 # class to support webcams
 class WebcamStream:
-    def __init__(self, src=0):
+    def __init__(self, src=0, resolution=(640, 480), framerate=30):
         self.logger = LogManager.get_logger(__name__)
         self.name = "WebcamStream"
         self.logger.info(f'Camera type: {self.name}')
         self.stream = cv2.VideoCapture(src)
 
-        self.frame_width = self.stream.get(cv2.CAP_PROP_FRAME_WIDTH)
-        self.frame_height = self.stream.get(cv2.CAP_PROP_FRAME_HEIGHT)
-
         # Check if the stream opened successfully
         if not self.stream.isOpened():
             self.stream.release()
             self.logger.error(f'Unable to open video source: {src}')
-            raise ValueError("Unable to open video source:", src)
+            raise ValueError(f'Unable to open video source: {src}')
+
+        target_width, target_height = resolution
+
+        self.stream.set(cv2.CAP_PROP_FRAME_WIDTH, target_width)
+        self.stream.set(cv2.CAP_PROP_FRAME_HEIGHT, target_height)
+        self.stream.set(cv2.CAP_PROP_FPS, framerate)
+
+        self.frame_width = int(self.stream.get(cv2.CAP_PROP_FRAME_WIDTH))
+        self.frame_height = int(self.stream.get(cv2.CAP_PROP_FRAME_HEIGHT))
+        actual_fps = self.stream.get(cv2.CAP_PROP_FPS)
+
+        if (self.frame_width, self.frame_height) != (target_width, target_height):
+            self.logger.warning(
+                f"Requested resolution {target_width}x{target_height}, "
+                f"but got {self.frame_width}x{self.frame_height} from webcam."
+            )
+
+        if actual_fps != 0 and abs(actual_fps - framerate) > 1:
+            self.logger.warning(
+                f"Requested FPS {framerate}, but webcam reports {actual_fps:.1f}."
+            )
 
         # read the first frame from the stream
         self.grabbed, self.frame = self.stream.read()
         if not self.grabbed:
             self.stream.release()
             self.logger.error(f'Unable to read from video source: {src}')
-            raise ValueError("Unable to read from video source:", src)
+            raise ValueError(f'Unable to read from video source: {src}')
 
         # initialize the thread name, stop event, and the thread itself
         self.stop_event = Event()
@@ -288,21 +306,42 @@ class VideoStream:
     def __init__(self, src=0, resolution=(416, 320), exp_compensation=-2, **kwargs):
         self.CAMERA_VERSION = PICAMERA_VERSION if PICAMERA_VERSION is not None else 'webcam'
         self.logger = LogManager.get_logger(__name__)
+        self.logger.info(f"[INFO] Initial camera backend selection: {self.CAMERA_VERSION} (src={src})")
         self.frame_height = None
         self.frame_width = None
 
-        if self.CAMERA_VERSION == 'legacy':
-            self.stream = PiCameraStream(resolution=resolution, exp_compensation=exp_compensation, **kwargs)
+        if self.CAMERA_VERSION == 'picamera2':
+            try:
+                self.stream = PiCamera2Stream(src=src,
+                                              resolution=resolution,
+                                              exp_compensation=exp_compensation,
+                                              **kwargs)
+            except Exception as e:
+                self.logger.warning(
+                    f"PiCamera2Stream failed ({e}); falling back to USB webcam.",
+                    exc_info=True
+                )
+                self.stream = WebcamStream(src=src, resolution=resolution)
 
-        elif self.CAMERA_VERSION == 'picamera2':
-            self.stream = PiCamera2Stream(src=src, resolution=resolution, exp_compensation=exp_compensation, **kwargs)
-
+        elif self.CAMERA_VERSION == 'legacy':
+            try:
+                self.stream = PiCameraStream(resolution=resolution,
+                                             exp_compensation=exp_compensation,
+                                             **kwargs)
+            except Exception as e:
+                self.logger.warning(
+                    f"PiCameraStream failed ({e}); falling back to USB webcam.",
+                    exc_info=True
+                )
+                self.stream = WebcamStream(src=src, resolution=resolution)
         elif self.CAMERA_VERSION == 'webcam':
-            self.stream = WebcamStream(src=src)
+            self.stream = WebcamStream(src=src, resolution=resolution)
 
         else:
-            self.logger.error(f"Unsupported camera version: {self.CAMERA_VERSION}")
-            raise ValueError(f"Unsupported camera version: {self.CAMERA_VERSION}")
+            self.logger.error(
+                f"[ERROR] Unsupported camera version: {self.CAMERA_VERSION}"
+            )
+            raise ValueError(f"[ERROR] Unsupported camera version: {self.CAMERA_VERSION}")
 
         # set the image dimensions directly from the frame streamed
         self.frame_width = self.stream.frame_width

--- a/utils/video_manager.py
+++ b/utils/video_manager.py
@@ -31,12 +31,9 @@ class WebcamStream:
         self.IS_PI = pi
 
         if self.IS_PI:
-            if isinstance(src, int):
-                device = f"/dev/video{src}"
-            else:
-                device = src
-            self.logger.info(f"[INFO] Opening webcam via V4L2 on device {device}")
-            self.stream = cv2.VideoCapture(device)
+            src = "/dev/video0"
+            self.logger.info(f"[INFO] Opening webcam via V4L2 on device {src}")
+            self.stream = cv2.VideoCapture(src)
         else:
             # Cross-platform default (Windows, macOS, generic Linux)
             self.logger.info(f"[INFO] Opening webcam via default backend on source {src}")

--- a/utils/video_manager.py
+++ b/utils/video_manager.py
@@ -33,7 +33,7 @@ class WebcamStream:
         if self.IS_PI:
             src = "/dev/video0"
             self.logger.info(f"[INFO] Opening webcam via V4L2 on device {src}")
-            self.stream = cv2.VideoCapture(src)
+            self.stream = cv2.VideoCapture("/dev/video0")
         else:
             # Cross-platform default (Windows, macOS, generic Linux)
             self.logger.info(f"[INFO] Opening webcam via default backend on source {src}")


### PR DESCRIPTION
# USB Camera Support & Config Validation

Adds proper USB UVC camera support and fixes configuration validation gaps. Fixes the issue in #186 

## What's Changed

### USB Camera Support
- New `camera_type` config option: `rpi`, `usb`, or `auto`
- `auto` detects platform and picks one - no fallback attempts (fallback was causing device locking issues when Pi camera init failed)
- Windows/Mac automatically use USB
- Fixed deadlock bug in `PiCamera2Stream.read()`

### Config Validation
- Validates `camera_type`, `sample_method`, and boolean fields
- Added `GreenOnGreen` and `Visualisation` section validation  
- GPIO pins checked against actual RPi pinout - rejects power/ground/reserved pins with helpful errors
- Relay section now dynamic - not hardcoded to 4 relays

### Setup Script
- Detects USB cameras via `v4l2-ctl` in addition to CSI cameras

## Config Example

```ini
[Camera]
camera_type = usb
```

## Breaking Changes
None - defaults to `auto` which works like before for standard setups.

## Testing
* Validated on a Raspberry Pi 5 with Global Shutter Camera and [720P USB 2.0 UVC Camera](https://www.amazon.com/dp/B0CLRJZG8D/)
* Validated on a Windows laptop with `auto`